### PR TITLE
[feat] Firebase SPM 전환

### DIFF
--- a/Cllog/.package.resolved
+++ b/Cllog/.package.resolved
@@ -1,0 +1,123 @@
+{
+  "originHash" : "a1569f9895aa2be8e24832f98525d5da4eb90b5d158a82691c15b47eb72a13d7",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "6318278e8e64d21f0fdcc69004395e4d34048aaf",
+        "version" : "11.8.1"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "be0881ff728eca210ccb628092af400c086abda3",
+        "version" : "11.7.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+        "version" : "8.0.2"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version" : "1.65.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "4d70340d55d7d07cc2fdf8e8125c4c126c1d5f35",
+        "version" : "4.4.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
+        "version" : "1.29.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Cllog/Projects/AppModule/Sample/Project.swift
+++ b/Cllog/Projects/AppModule/Sample/Project.swift
@@ -12,6 +12,17 @@ let project = Project.configure(
     moduleType: .app,
     product: .app,
     dependencies: [
-        .Modules.umbrella
+        .Modules.umbrella,
+        
+        .SPM.firebaseCore,
+        .SPM.firebaseAuth,
+        .SPM.firebaseAnalytics,
+        .SPM.firebaseMessaging,
+        .SPM.firebaseCrashlytics,
+        .SPM.firebasePerformance,
+        .SPM.firebaseRemoteConfig,
+    ],
+    packages: [
+        .remote(url: "https://github.com/firebase/firebase-ios-sdk.git", requirement: .exact("11.8.1"))
     ]
 )

--- a/Cllog/Projects/AppModule/Sample/Sources/Core/AppDelegate.swift
+++ b/Cllog/Projects/AppModule/Sample/Sources/Core/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+
 import Firebase
  
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Cllog/Projects/CllogService/CoreKit/Core/Project.swift
+++ b/Cllog/Projects/CllogService/CoreKit/Core/Project.swift
@@ -14,11 +14,5 @@ let project = Project.configure(
     dependencies: [
         .Core.designKit(.cllog),
         .Domains.Domain.domain(.cllog),
-        .Library.firebaseAuth,
-        .Library.firebaseAnalytics,
-        .Library.firebaseMessaging,
-        .Library.firebaseCrashlytics,
-        .Library.firebasePerformance,
-        .Library.firebaseRemoteConfig,
     ]
 )

--- a/Cllog/Tuist/Package.resolved
+++ b/Cllog/Tuist/Package.resolved
@@ -1,120 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/abseil-cpp-binary.git",
-      "state" : {
-        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
-        "version" : "1.2024011602.0"
-      }
-    },
-    {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
         "revision" : "bc268c28fb170f494de9e9927c371b8342979ece",
         "version" : "5.7.1"
-      }
-    },
-    {
-      "identity" : "app-check",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/app-check.git",
-      "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
-      }
-    },
-    {
-      "identity" : "firebase-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
-      "state" : {
-        "revision" : "6318278e8e64d21f0fdcc69004395e4d34048aaf",
-        "version" : "11.8.1"
-      }
-    },
-    {
-      "identity" : "googleappmeasurement",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
-      "state" : {
-        "revision" : "be0881ff728eca210ccb628092af400c086abda3",
-        "version" : "11.7.0"
-      }
-    },
-    {
-      "identity" : "googledatatransport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
-      "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
-      }
-    },
-    {
-      "identity" : "googleutilities",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleUtilities.git",
-      "state" : {
-        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
-        "version" : "8.0.2"
-      }
-    },
-    {
-      "identity" : "grpc-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/grpc-binary.git",
-      "state" : {
-        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
-        "version" : "1.65.1"
-      }
-    },
-    {
-      "identity" : "gtm-session-fetcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/gtm-session-fetcher.git",
-      "state" : {
-        "revision" : "4d70340d55d7d07cc2fdf8e8125c4c126c1d5f35",
-        "version" : "4.4.0"
-      }
-    },
-    {
-      "identity" : "interop-ios-for-google-sdks",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
-      "state" : {
-        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
-        "version" : "100.0.0"
-      }
-    },
-    {
-      "identity" : "leveldb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
-      "state" : {
-        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
-        "version" : "1.22.5"
-      }
-    },
-    {
-      "identity" : "nanopb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
-      "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
-      }
-    },
-    {
-      "identity" : "promises",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
-      "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
       }
     },
     {
@@ -133,15 +25,6 @@
       "state" : {
         "revision" : "f222cbdf325885926566172f6f5f06af95473158",
         "version" : "5.6.0"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
       }
     },
     {

--- a/Cllog/Tuist/Package.swift
+++ b/Cllog/Tuist/Package.swift
@@ -10,8 +10,7 @@ import ProjectDescriptionHelpers
             "SnapKit": .framework,
             "Alamofire": .framework,
             "Then": .framework,
-            "Pulse": .framework,
-            "Firebase": .framework,
+            "Pulse": .framework
         ],
         baseSettings: Settings.settings(configurations: XCConfig.framework)
     )
@@ -24,7 +23,6 @@ let package = Package(
         .package(url: "https://github.com/SnapKit/SnapKit.git", exact: "5.6.0"),
         .package(url: "https://github.com/Alamofire/Alamofire.git", exact: "5.7.1"),
         .package(url: "https://github.com/devxoul/Then.git", exact: "3.0.0"),
-        .package(url: "https://github.com/kean/Pulse.git", exact: "5.1.2"),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "11.8.1")
+        .package(url: "https://github.com/kean/Pulse.git", exact: "5.1.2")
     ]
 )

--- a/Cllog/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Library.swift
+++ b/Cllog/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Library.swift
@@ -10,6 +10,7 @@ import ProjectDescription
 public extension TargetDependency {
     struct Framework {}
     struct Library {}
+    struct SPM {}
 }
 
 public extension TargetDependency.Framework {
@@ -20,15 +21,19 @@ public extension TargetDependency.Library {
     static let snapKit = TargetDependency.external(name: "SnapKit")
     static let alamofire = TargetDependency.external(name: "Alamofire")
     static let then = TargetDependency.external(name: "Then")
-    static let firebaseAuth = TargetDependency.external(name: "FirebaseAuth")
-    static let firebaseAnalytics = TargetDependency.external(name: "FirebaseAnalytics")
-    static let firebaseRemoteConfig = TargetDependency.external(name: "FirebaseRemoteConfig")
-    static let firebaseMessaging = TargetDependency.external(name: "FirebaseMessaging")
-    static let firebasePerformance = TargetDependency.external(name: "FirebasePerformance")
-    static let firebaseCrashlytics = TargetDependency.external(name: "FirebaseCrashlytics")
     
     // 네트워크
     static let pulse = TargetDependency.external(name: "Pulse")
     static let pulseUI = TargetDependency.external(name: "PulseUI")
     static let pulseProxy = TargetDependency.external(name: "PulseProxy")
+}
+
+public extension TargetDependency.SPM {
+    static let firebaseCore = TargetDependency.package(product: "FirebaseCore")
+    static let firebaseAuth = TargetDependency.package(product: "FirebaseAuth")
+    static let firebaseAnalytics = TargetDependency.package(product: "FirebaseAnalytics")
+    static let firebaseRemoteConfig = TargetDependency.package(product: "FirebaseRemoteConfig")
+    static let firebaseMessaging = TargetDependency.package(product: "FirebaseMessaging")
+    static let firebasePerformance = TargetDependency.package(product: "FirebasePerformance")
+    static let firebaseCrashlytics = TargetDependency.package(product: "FirebaseCrashlytics")
 }

--- a/Cllog/Tuist/ProjectDescriptionHelpers/Template/Project+Template.swift
+++ b/Cllog/Tuist/ProjectDescriptionHelpers/Template/Project+Template.swift
@@ -12,6 +12,7 @@ extension Project {
         moduleType: ModuleType,
         product: Product,
         dependencies: [TargetDependency],
+        packages: [Package] = [],
         hasTests: Bool = true,
         hasResources: Bool = false
     ) -> Project {
@@ -45,6 +46,7 @@ extension Project {
             return Project(
                 name: configuration.projectName,
                 organizationName: configuration.organizationName,
+                packages: packages,
                 settings: configuration.setting,
                 targets: targets,
                 schemes: schemes


### PR DESCRIPTION
- Tuist에서 Objective-c를 참조하지 못하는 이슈가 있음,
- .h 파일을 참조하지 못해서 SPM 전환이 필요하여 변경

## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- Firebase SPM 전환
- Firebase Plist가 없어 로그콘솔에 에로가 표시가 되는 문제가 있음
- 추후 plist 추가가 필요

## 관련링크 (JIRA)
<!--
- 관련링크를 나열합니다.
-->

-

관련 로그, 스크린샷
---
<!--
- 관련 로그나 스크린샷이 필요한 경우 나열합니다.
- 관련이 없으면 삭제합니다.
-->

| 작업전 | 작업후 |
| --- | --- |
|![작업전](path/asis) |![작업후](path/tobe) |
