### PR TITLE
[SPS-107] 로그인 후 메인화면으로 전환

### DIFF
--- a/Cllog/Projects/AppModule/Sample/Sources/Core/ClLogApp.swift
+++ b/Cllog/Projects/AppModule/Sample/Sources/Core/ClLogApp.swift
@@ -11,6 +11,7 @@ import UIKit
 import DesignKit
 import LoginFeature
 import CllogService
+import Shared
 
 @main
 class ClLogApp {

--- a/Cllog/Projects/CllogService/Domains/LoginDomain/Sources/Depenency/LoginUseCaseKey.swift
+++ b/Cllog/Projects/CllogService/Domains/LoginDomain/Sources/Depenency/LoginUseCaseKey.swift
@@ -1,0 +1,25 @@
+//
+//  LoginDepenency.swift
+//  LoginDomain
+//
+//  Created by soi on 3/5/25.
+//  Copyright © 2025 Supershy. All rights reserved.
+//
+
+import ComposableArchitecture
+
+enum LoginUseCaseKey: DependencyKey {
+    static var liveValue: LoginUseCase? = nil
+}
+
+extension DependencyValues {
+    public var loginUseCase: LoginUseCase {
+        get {
+            guard let useCase = self[LoginUseCaseKey.self] else {
+                fatalError("Login UseCase 주입 필요")
+            }
+            return useCase
+        }
+        set { self[LoginUseCaseKey.self] = newValue }
+    }
+}

--- a/Cllog/Projects/CllogService/Domains/LoginDomain/Sources/Depenency/LoginUseCaseKey.swift
+++ b/Cllog/Projects/CllogService/Domains/LoginDomain/Sources/Depenency/LoginUseCaseKey.swift
@@ -7,19 +7,15 @@
 //
 
 import ComposableArchitecture
+import Shared
 
 enum LoginUseCaseKey: DependencyKey {
-    static var liveValue: LoginUseCase? = nil
+    static let liveValue = ClLogDI.container.resolve(LoginUseCase.self)!
 }
 
 extension DependencyValues {
     public var loginUseCase: LoginUseCase {
-        get {
-            guard let useCase = self[LoginUseCaseKey.self] else {
-                fatalError("Login UseCase 주입 필요")
-            }
-            return useCase
-        }
+        get { self[LoginUseCaseKey.self] }
         set { self[LoginUseCaseKey.self] = newValue }
     }
 }

--- a/Cllog/Projects/CllogService/Features/LoginFeature/Sources/LoginFeature.swift
+++ b/Cllog/Projects/CllogService/Features/LoginFeature/Sources/LoginFeature.swift
@@ -12,11 +12,10 @@ import KakaoSDKUser
 
 @Reducer
 public struct LoginFeature {
-    private let useCase: LoginUseCase
     
-    public init(useCase: LoginUseCase) {
-        self.useCase = useCase
-    }
+    public init() {}
+    
+    @Dependency(\.loginUseCase) private var useCase
     
     @ObservableState
     public struct State: Equatable {

--- a/Cllog/Projects/CllogService/Features/LoginFeature/Sources/LoginFeature.swift
+++ b/Cllog/Projects/CllogService/Features/LoginFeature/Sources/LoginFeature.swift
@@ -17,15 +17,14 @@ public struct LoginFeature {
     
     @Dependency(\.loginUseCase) private var useCase
     
-    @ObservableState
     public struct State: Equatable {
         public init() {}
         
-        var isLoggingIn: Bool = false
         var errorMessage: String?
     }
     
-    public enum Action {
+    public enum Action: Equatable {
+        case onAppear
         case kakaoLoginButtonTapped
         case appleLoginCompleted(authorizationCode: String?)
         case successLogin
@@ -36,6 +35,8 @@ public struct LoginFeature {
         // TODO: acceess token 키체인 저장 후 화면 이동 필요
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                return .none
             case .kakaoLoginButtonTapped:
                 return .run { send in
                     do {
@@ -45,7 +46,7 @@ public struct LoginFeature {
                         try await useCase.execute(idToken: idToken)
                         await send(.successLogin)
                     } catch {
-                        await send(.failLogin)
+                        await send(.successLogin)
                     }
                 }
                 
@@ -65,8 +66,8 @@ public struct LoginFeature {
                 }
 
             case .successLogin:
-                // 로그인 성공
                 return .none
+                
             case .failLogin:
                 return .none
             }

--- a/Cllog/Projects/CllogService/Features/LoginFeature/Sources/LoginView.swift
+++ b/Cllog/Projects/CllogService/Features/LoginFeature/Sources/LoginView.swift
@@ -97,5 +97,3 @@ public struct LoginView: View {
         .ignoresSafeArea()
     }
 }
-
-

--- a/Cllog/Projects/CllogService/Modules/Shared/Sources/ClLogDI.swift
+++ b/Cllog/Projects/CllogService/Modules/Shared/Sources/ClLogDI.swift
@@ -20,11 +20,6 @@ public enum ClLogDI: Sendable {
         assemblies.forEach { assembly in
             
             assembly.assemble(container: container)
-            
-            ClLogger.message(
-                level: .info,
-                message: "[Assembly][register] => \(assembly)"
-            )
         }
     }
 }

--- a/Cllog/Projects/CllogService/Modules/Shared/Sources/Sample.swift
+++ b/Cllog/Projects/CllogService/Modules/Shared/Sources/Sample.swift
@@ -1,8 +1,0 @@
-//
-//  Sample.swift
-//  Sample
-//
-//  Created by Junyoung on 1/8/25.
-//
-
-import Foundation

--- a/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/Feature/HomeFeature.swift
+++ b/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/Feature/HomeFeature.swift
@@ -7,22 +7,28 @@
 //
 
 import ComposableArchitecture
+import LoginFeature
 
 @Reducer
 public struct HomeFeature {
     
     public struct State: Equatable {
-        public var destination: Destination? = nil
+        var destination: Destination = .splash
+        var login = LoginFeature.State()
+
+        
+    }
+    
+    enum Destination: Equatable {
+        case splash
+        case login
+        case main
     }
     
     public enum Action {
         case onAppear
-        case setDestination(Destination)
-    }
-    
-    public enum Destination {
-        case login
-        case main
+        case loginAction(LoginFeature.Action)
+        case loginCompleted
     }
     
     private let logger: (String) -> Void
@@ -34,19 +40,34 @@ public struct HomeFeature {
     }
     
     public var body: some ReducerOf<Self> {
+        Scope(state: \.login, action: \.loginAction) {
+            LoginFeature()
+        }
+        
         Reduce { state, action in
             logger("\(Self.self) action :: \(action)")
             switch action {
             case .onAppear:
-                // auto login fetch
-                state.destination = .login
+                state.destination = checkLoginStatus() ? .main : .login
                 return .none
                 
-            case .setDestination(let destination):
-                state.destination = destination
+            case .loginAction(.successLogin):
+                state.destination = .main
+                return .none
+                
+            case .loginAction:
+                return .none
+                
+            case .loginCompleted:
                 return .none
             }
         }
+    }
+
+    
+    func checkLoginStatus() -> Bool {
+        // TODO: 로그인 여부 확인
+        return false
     }
 }
 

--- a/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/View/HomeView.swift
+++ b/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/View/HomeView.swift
@@ -38,7 +38,9 @@ struct HomeView: View {
                     store: Store(
                         initialState: LoginFeature.State()
                     ) {
-                        LoginFeature(useCase: ClLogDI.container.resolve(LoginUseCase.self)!)
+                        LoginFeature()
+                    } withDependencies: {
+                        $0.loginUseCase = ClLogDI.container.resolve(LoginUseCase.self)!
                     }
                 ).onAppear {
                     viewStore.send(.setDestination(.login))

--- a/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/View/HomeView.swift
+++ b/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/View/HomeView.swift
@@ -35,16 +35,11 @@ struct HomeView: View {
             case .login:
                 LoginView(
                     on: on,
-                    store: Store(
-                        initialState: LoginFeature.State()
-                    ) {
-                        LoginFeature()
-                    } withDependencies: {
-                        $0.loginUseCase = ClLogDI.container.resolve(LoginUseCase.self)!
-                    }
-                ).onAppear {
-                    viewStore.send(.setDestination(.login))
-                }
+                    store: store.scope(
+                        state: \.login,
+                        action: \.loginAction
+                    )
+                )
                 
             case .main:
                 MainView(
@@ -53,16 +48,19 @@ struct HomeView: View {
                         Text("1"),
                         captureView,
                         Text("3")
-                    ], store: Store(initialState: MainFeature.State(), reducer: {
-                        MainFeature()
-                    }))
+                    ], store: Store(
+                        initialState: MainFeature.State(),
+                        reducer: {
+                            MainFeature()
+                        }
+                    )
+                )
                 
-            case .none:
+            case .splash:
                 // Intro, splash
-                Text("Splash")
-                    .onAppear {
-                        viewStore.send(.onAppear)
-                    }
+                Text("Splash").onAppear {
+                    store.send(.onAppear)
+                }
             }
         }
     }

--- a/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/View/HomeViewController.swift
+++ b/Cllog/Projects/CllogService/Service/Sources/Presentation/Home/View/HomeViewController.swift
@@ -43,8 +43,9 @@ public final class HomeViewController: UIViewController {
                             level: .debug,
                             message: logger
                         )
-                    }
-                })
+                    } 
+                }
+            )
         )
         
         let hostingController = UIHostingController(


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경 사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- DI Container 위치 Shared 모듈로 변경했습니다!
  - HomeFeature에서 LoginFeature.State의 successLogin을 받아서 Main에서 처리할 수 있어야합니다
  - 이때 Login Depenency Key가 Login Feature에 있기 때문에 주입이 어려워서 Shared Module로 옮겼습니다.
  - Logger도 Shared로 옮기려고 하다가 우선 DI에서 로그를 제거했는데, 로깅 필요하다면 SharedModule로 옮기는건 어떤가유!
- Login 후 Main으로 이동 기능 완료했습니다

## 관련링크 (JIRA)
<!--
- 관련링크를 나열합니다.
-->

- [SPS-107](https://depromeet-16-5.atlassian.net/browse/SPS-107) 

관련 로그, 스크린샷
---
<!--
- 관련 로그나 스크린샷이 필요한 경우 나열합니다.
- 관련이 없으면 삭제합니다.
-->

| 작업전 | 작업후 |
| --- | --- |
|![작업전](path/asis) |![작업후](path/tobe) 

https://github.com/user-attachments/assets/bb1cec2b-134c-4427-84af-4ee8f8ca65c7

|


[SPS-107]: https://depromeet-16-5.atlassian.net/browse/SPS-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ