### PR TITLE
[SPS-149] 난이도 선택 바텀시트 UI

### DIFF
--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Resources/Asset/Assets.xcassets/icons/check.imageset/Contents.json
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Resources/Asset/Assets.xcassets/icons/check.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "check.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Resources/Asset/Assets.xcassets/icons/check.imageset/check.svg
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Resources/Asset/Assets.xcassets/icons/check.imageset/check.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="11" viewBox="0 0 14 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5L5 9L13 1" stroke="#191B1E" stroke-width="1.5"/>
+</svg>

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/Button/CheckBoxButton.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/Button/CheckBoxButton.swift
@@ -1,0 +1,57 @@
+//
+//  CheckBoxButton.swift
+//  DesignKit
+//
+//  Created by soi on 3/15/25.
+//  Copyright © 2025 Supershy. All rights reserved.
+//
+
+import SwiftUI
+
+public struct CheckBoxButton: View {
+    @Binding private var isActive: Bool
+    private let text: String
+    
+    public init(isActive: Binding<Bool>, text: String) {
+        self._isActive = isActive
+        self.text = text
+    }
+    
+    public var body: some View {
+        Button {
+            isActive.toggle()
+        } label: {
+            HStack(spacing: 6) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8)
+                        .frame(width: 24, height: 24)
+                        .foregroundStyle(isActive ? Color.clLogUI.primary : Color.clLogUI.gray600)
+                    
+                    if isActive {
+                        ClLogUI.check
+                            .foregroundStyle(Color.clLogUI.gray900)
+                    }
+                }
+                
+                Text(text)
+                    .foregroundStyle(
+                        isActive
+                        ? Color.clLogUI.gray50
+                        : Color.clLogUI.gray100
+                    )
+                    .font(.h4)
+            }
+        }
+    }
+}
+
+struct CheckBoxButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 16) {
+            CheckBoxButton(isActive: .constant(true), text: "선택됨")
+            CheckBoxButton(isActive: .constant(false), text: "선택 안됨")
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/Button/CheckBoxButton.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/Button/CheckBoxButton.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 public struct CheckBoxButton: View {
     @Binding private var isActive: Bool
-    private let text: String
+    private let title: String
     
-    public init(isActive: Binding<Bool>, text: String) {
+    public init(title: String, isActive: Binding<Bool>) {
+        self.title = title
         self._isActive = isActive
-        self.text = text
     }
     
     public var body: some View {
@@ -33,7 +33,7 @@ public struct CheckBoxButton: View {
                     }
                 }
                 
-                Text(text)
+                Text(title)
                     .foregroundStyle(
                         isActive
                         ? Color.clLogUI.gray50
@@ -48,8 +48,8 @@ public struct CheckBoxButton: View {
 struct CheckBoxButton_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 16) {
-            CheckBoxButton(isActive: .constant(true), text: "선택됨")
-            CheckBoxButton(isActive: .constant(false), text: "선택 안됨")
+            CheckBoxButton(title: "선택됨", isActive: .constant(true))
+            CheckBoxButton(title: "선택 안됨", isActive: .constant(false))
         }
         .padding()
         .previewLayout(.sizeThatFits)

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/GradeBottomSheet.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/GradeBottomSheet.swift
@@ -20,7 +20,6 @@ public extension View {
             SelectGradeView(
                 cragName: cragName,
                 grades: grades,
-                isPresented: isPresented,
                 didTapSaveButton: didTapSaveButton,
                 didTapCragTitleButton: didTapCragTitleButton
             )
@@ -46,13 +45,11 @@ struct SelectGradeView: View {
     init(
         cragName: String,
         grades: [DesignGrade],
-        isPresented: Binding<Bool>,
         didTapSaveButton: @escaping (DesignGrade?) -> Void,
         didTapCragTitleButton: @escaping() -> Void
     ) {
         self.cragName = cragName
         self.grades = grades
-        self._isPresented = isPresented
         self.didTapSaveButton = didTapSaveButton
         self.didTapCragTitleButton = didTapCragTitleButton
     }
@@ -169,7 +166,6 @@ struct SelectGradeView_Previews: PreviewProvider {
                 DesignGrade(name: "V2", color: .green),
                 DesignGrade(name: "V3", color: .red),
             ],
-            isPresented: .constant(false),
             didTapSaveButton: { _ in
                 
             },

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
@@ -8,6 +8,26 @@
 
 import SwiftUI
 
+public extension View {
+    func showGradeBottomSheet(
+        isPresented: Binding<Bool>,
+        cragName: String,
+        grades: [DesignGrade],
+        didTapSaveButton: @escaping (DesignGrade?) -> Void,
+        didTapCragTitleButton: @escaping () -> Void
+    ) -> some View {
+        self.bottomSheet(isPresented: isPresented) {
+            SelectGradeView(
+                cragName: cragName,
+                grades: grades,
+                isPresented: isPresented,
+                didTapSaveButton: didTapSaveButton,
+                didTapCragTitleButton: didTapCragTitleButton
+            )
+        }
+    }
+}
+
 public struct DesignGrade: Hashable, Identifiable {
     public var id: UUID
     
@@ -21,16 +41,18 @@ public struct DesignGrade: Hashable, Identifiable {
     public let color: Color
 }
 
-public struct SelectGradeView: View {
+struct SelectGradeView: View {
     
-    public init(
+    init(
         cragName: String,
         grades: [DesignGrade],
+        isPresented: Binding<Bool>,
         didTapSaveButton: @escaping (DesignGrade?) -> Void,
         didTapCragTitleButton: @escaping() -> Void
     ) {
         self.cragName = cragName
         self.grades = grades
+        self._isPresented = isPresented
         self.didTapSaveButton = didTapSaveButton
         self.didTapCragTitleButton = didTapCragTitleButton
     }
@@ -40,10 +62,11 @@ public struct SelectGradeView: View {
     private var didTapSaveButton: (DesignGrade?) -> Void
     private var didTapCragTitleButton: () -> Void
     
+    @Binding private var isPresented: Bool
     @State private var selectedGrade: DesignGrade?
     @State private var selectedUnSaveGrade: Bool = false
     
-    public var body: some View {
+    var body: some View {
         VStack(alignment: .leading) {
             cragTitleSection
             gradeSelectionSection
@@ -130,6 +153,7 @@ public struct SelectGradeView: View {
     
     private var saveButtonSection: some View {
         GeneralButton("저장하기") {
+            isPresented = false
             didTapSaveButton(selectedGrade)
         }
         .style(.white)
@@ -145,6 +169,7 @@ struct SelectGradeView_Previews: PreviewProvider {
                 DesignGrade(name: "V2", color: .green),
                 DesignGrade(name: "V3", color: .red),
             ],
+            isPresented: .constant(false),
             didTapSaveButton: { _ in
                 
             },

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
@@ -1,0 +1,131 @@
+//
+//  SelectGradeView.swift
+//  DesignKit
+//
+//  Created by soi on 3/15/25.
+//  Copyright © 2025 Supershy. All rights reserved.
+//
+
+import SwiftUI
+
+public struct DesignGrade: Hashable, Identifiable {
+    public var id: UUID
+    
+    public init(name: String, color: Color) {
+        self.id = UUID()
+        self.name = name
+        self.color = color
+    }
+    
+    public let name: String
+    public let color: Color
+}
+
+public struct SelectGradeView: View {
+    
+    public init(
+        cragName: String,
+        grades: [DesignGrade],
+        selectedGrade: Binding<DesignGrade?>,
+        selectedUnSaveGrade: Binding<Bool>,
+        didTapSaveButton: @escaping () -> Void,
+        didTapCragTitleButton: @escaping() -> Void
+    ) {
+        self.cragName = cragName
+        self.grades = grades
+        self._selectedGrade = selectedGrade
+        self._selectedUnSaveGrade = selectedUnSaveGrade
+        self.didTapSaveButton = didTapSaveButton
+        self.didTapCragTitleButton = didTapCragTitleButton
+    }
+    
+    private let cragName: String
+    private let grades: [DesignGrade]
+    @Binding private var selectedGrade: DesignGrade?
+    @Binding private var selectedUnSaveGrade: Bool
+    private var didTapSaveButton: () -> Void
+    private var didTapCragTitleButton: () -> Void
+    
+    public var body: some View {
+        VStack(alignment: .leading) {
+            Text("암장명")
+                .font(.h3)
+                .foregroundStyle(Color.clLogUI.white)
+            
+            Button {
+                print("tapped")
+            } label: {
+                Text(cragName)
+                    .font(.b1)
+                    .foregroundStyle(Color.clLogUI.gray50)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(Color.clLogUI.gray900)
+            .cornerRadius(12)
+            
+            Text("문제 난이도")
+                .font(.h3)
+                .foregroundStyle(Color.clLogUI.white)
+                .padding(.top, 16)
+                .padding(.bottom, 10)
+            
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 36, maximum: 36), spacing: 28)]) {
+                ForEach(grades, id: \.self) { grade in
+                    Circle()
+                        .foregroundStyle(grade.color)
+                        .overlay(
+                            Circle()
+                                .strokeBorder(
+                                    selectedGrade == grade ? Color.clLogUI.white : Color.clear,
+                                    lineWidth: 3
+                                )
+                        )
+                        .onTapGesture {
+                            selectedGrade = grade
+                        }
+                }
+            }
+            .padding(.vertical, 16)
+            .background(Color.clLogUI.gray900)
+            .cornerRadius(12)
+            
+            CheckBoxButton(
+                title: "난이도 미등록",
+                isActive: $selectedUnSaveGrade
+            )
+            .padding(.top, 10)
+            .padding(.bottom, 40)
+            
+            GeneralButton("저장하기") {
+                print("저장")
+            }
+            .style(.white)
+        }
+        .background(Color.clLogUI.gray800)
+    }
+}
+
+struct SelectGradeView_Previews: PreviewProvider {
+    static var previews: some View {
+        SelectGradeView(
+            cragName: "한남 암장",
+            grades: [
+                DesignGrade(name: "V1", color: .blue),
+                DesignGrade(name: "V2", color: .green),
+                DesignGrade(name: "V3", color: .red),
+            ],
+            selectedGrade: .constant(nil),
+            selectedUnSaveGrade: .constant(false),
+            didTapSaveButton: {
+                
+            },
+            didTapCragTitleButton: {
+                
+            }
+        )
+        .previewLayout(.sizeThatFits)
+        .padding()
+    }
+}

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
@@ -45,12 +45,33 @@ public struct SelectGradeView: View {
     
     public var body: some View {
         VStack(alignment: .leading) {
+            cragTitleSection
+            gradeSelectionSection
+            checkboxSection
+            saveButtonSection
+        }
+        .background(Color.clLogUI.gray800)
+        .onChange(of: selectedGrade) { _, newValue in
+            if selectedUnSaveGrade, newValue != nil {
+                selectedUnSaveGrade = false
+            }
+        }
+        .onChange(of: selectedUnSaveGrade) { _, newValue in
+            if newValue, selectedGrade != nil {
+                selectedGrade = nil
+            }
+        }
+    }
+    
+    // MARK: - UI Components
+    private var cragTitleSection: some View {
+        VStack(alignment: .leading) {
             Text("암장명")
                 .font(.h3)
                 .foregroundStyle(Color.clLogUI.white)
             
             Button {
-                print("tapped")
+                didTapCragTitleButton()
             } label: {
                 Text(cragName)
                     .font(.b1)
@@ -61,7 +82,11 @@ public struct SelectGradeView: View {
             }
             .background(Color.clLogUI.gray900)
             .cornerRadius(12)
-            
+        }
+    }
+    
+    private var gradeSelectionSection: some View {
+        VStack(alignment: .leading) {
             Text("문제 난이도")
                 .font(.h3)
                 .foregroundStyle(Color.clLogUI.white)
@@ -70,48 +95,44 @@ public struct SelectGradeView: View {
             
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 36, maximum: 36), spacing: 28)]) {
                 ForEach(grades, id: \.self) { grade in
-                    Circle()
-                        .foregroundStyle(grade.color)
-                        .overlay(
-                            Circle()
-                                .strokeBorder(
-                                    selectedGrade == grade ? Color.clLogUI.white : Color.clear,
-                                    lineWidth: 3
-                                )
-                        )
-                        .onTapGesture {
-                            selectedGrade = grade
-                        }
+                    gradeGradeChip(for: grade)
                 }
             }
             .padding(.vertical, 16)
             .background(Color.clLogUI.gray900)
             .cornerRadius(12)
-            
-            CheckBoxButton(
-                title: "난이도 미등록",
-                isActive: $selectedUnSaveGrade
+        }
+    }
+    
+    private func gradeGradeChip(for grade: DesignGrade) -> some View {
+        Circle()
+            .foregroundStyle(grade.color)
+            .overlay(
+                Circle()
+                    .strokeBorder(
+                        selectedGrade == grade ? Color.clLogUI.white : Color.clear,
+                        lineWidth: 3
+                    )
             )
-            
-            .padding(.top, 10)
-            .padding(.bottom, 40)
-            
-            GeneralButton("저장하기") {
-                didTapSaveButton(selectedGrade)
+            .onTapGesture {
+                selectedGrade = grade
             }
-            .style(.white)
+    }
+    
+    private var checkboxSection: some View {
+        CheckBoxButton(
+            title: "난이도 미등록",
+            isActive: $selectedUnSaveGrade
+        )
+        .padding(.top, 10)
+        .padding(.bottom, 40)
+    }
+    
+    private var saveButtonSection: some View {
+        GeneralButton("저장하기") {
+            didTapSaveButton(selectedGrade)
         }
-        .background(Color.clLogUI.gray800)
-        .onChange(of: selectedGrade) { _, newValue in
-            if selectedUnSaveGrade, newValue != nil {
-                selectedUnSaveGrade = false
-            }
-        }
-        .onChange(of: selectedUnSaveGrade) {_, newValue in
-            if newValue, selectedGrade != nil {
-                selectedGrade = nil
-            }
-        }
+        .style(.white)
     }
 }
 

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Component/View/SelectGradeView.swift
@@ -26,25 +26,22 @@ public struct SelectGradeView: View {
     public init(
         cragName: String,
         grades: [DesignGrade],
-        selectedGrade: Binding<DesignGrade?>,
-        selectedUnSaveGrade: Binding<Bool>,
-        didTapSaveButton: @escaping () -> Void,
+        didTapSaveButton: @escaping (DesignGrade?) -> Void,
         didTapCragTitleButton: @escaping() -> Void
     ) {
         self.cragName = cragName
         self.grades = grades
-        self._selectedGrade = selectedGrade
-        self._selectedUnSaveGrade = selectedUnSaveGrade
         self.didTapSaveButton = didTapSaveButton
         self.didTapCragTitleButton = didTapCragTitleButton
     }
     
     private let cragName: String
     private let grades: [DesignGrade]
-    @Binding private var selectedGrade: DesignGrade?
-    @Binding private var selectedUnSaveGrade: Bool
-    private var didTapSaveButton: () -> Void
+    private var didTapSaveButton: (DesignGrade?) -> Void
     private var didTapCragTitleButton: () -> Void
+    
+    @State private var selectedGrade: DesignGrade?
+    @State private var selectedUnSaveGrade: Bool = false
     
     public var body: some View {
         VStack(alignment: .leading) {
@@ -95,15 +92,26 @@ public struct SelectGradeView: View {
                 title: "난이도 미등록",
                 isActive: $selectedUnSaveGrade
             )
+            
             .padding(.top, 10)
             .padding(.bottom, 40)
             
             GeneralButton("저장하기") {
-                print("저장")
+                didTapSaveButton(selectedGrade)
             }
             .style(.white)
         }
         .background(Color.clLogUI.gray800)
+        .onChange(of: selectedGrade) { _, newValue in
+            if selectedUnSaveGrade, newValue != nil {
+                selectedUnSaveGrade = false
+            }
+        }
+        .onChange(of: selectedUnSaveGrade) {_, newValue in
+            if newValue, selectedGrade != nil {
+                selectedGrade = nil
+            }
+        }
     }
 }
 
@@ -116,9 +124,7 @@ struct SelectGradeView_Previews: PreviewProvider {
                 DesignGrade(name: "V2", color: .green),
                 DesignGrade(name: "V3", color: .red),
             ],
-            selectedGrade: .constant(nil),
-            selectedUnSaveGrade: .constant(false),
-            didTapSaveButton: {
+            didTapSaveButton: { _ in
                 
             },
             didTapCragTitleButton: {

--- a/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Core/DesignSystem/Image.swift
+++ b/Cllog/Projects/CllogService/CoreKit/DesignKit/Sources/Core/DesignSystem/Image.swift
@@ -36,6 +36,7 @@ extension ClLogUI where Base == UIImage {
     public static var calendarAfter: UIImage { asset(#function) }
     public static var calendarBefore: UIImage { asset(#function) }
     public static var time: UIImage { asset(#function) }
+    public static var check: UIImage { asset(#function) }
 }
 
 extension ClLogUI where Base == Image {
@@ -67,6 +68,7 @@ extension ClLogUI where Base == Image {
     public static var calendarBefore: Image { asset(#function) }
     public static var time: Image { asset(#function) }
     public static var icn_close: Image { asset(#function) }
+    public static var check: Image { asset(#function) }
     
     // Edit
     public static var playSmall: Image { asset(#function) }


### PR DESCRIPTION
## 변경 유형
<!--
- 변경 유형을 체크해주세요
-->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 업데이트

## 변경사항
<!--
- 이 PR에서 수행한 변경 사항을 간단히 요약해주세요
-->

- 체크박스 버튼 생성
- 난이도 선택 바텀 시트 생성

## 고민 사항

- DesignGrade 구조체
  - Design Kit 안에서 구조체를 요구하게 되면서 Domain <-> DesignModel로 전환하는 로직이 필요한데, 개선할 수 있나.. 🤔
- title label tap escaping
  - 응답이 어떻게 올지 모르겠는데, 만약 암장 정보 + 난이도 정보가 같이오게 되면 title view tap escaping 없이 자체적으로 이동해도 괜찮을 것 같긴 해!
  - (+ 암장 이름 버튼 선택 시, 암장 선택 bottom sheet을 보여주어야함)

## 관련링크 (JIRA)
<!--
- 관련링크를 나열합니다.
-->

-https://depromeet-16-5.atlassian.net/jira/software/projects/SPS/boards/1?selectedIssue=SPS-149

관련 로그, 스크린샷
---
<!--
- 관련 로그나 스크린샷이 필요한 경우 나열합니다.
- 관련이 없으면 삭제합니다.
-->

https://github.com/user-attachments/assets/ba3ba291-3938-4b6c-acfd-6be05c69905e

